### PR TITLE
STAT-990: Fix "coffee-cup-date" attribute split.

### DIFF
--- a/app/assets/javascripts/coffee_cup/controllers/application_controller.coffee
+++ b/app/assets/javascripts/coffee_cup/controllers/application_controller.coffee
@@ -9,7 +9,8 @@ class ApplicationController
 
   loadView: ->
     if $('body').data('coffee-cup')
-      CoffeeCup.renderView $('body').data('coffee-cup').split('#').join('.')
+      # Split on "#" (controller action) and "::" (controller namespace).
+      CoffeeCup.renderView $('body').data('coffee-cup').split(/#|::/).join('.')
     else
       alert 'Coffee Cup : Installation incomplete. Please insert the body attribute "data-coffee-cup". See documentation for more details.'
 

--- a/coffee-cup.gemspec
+++ b/coffee-cup.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "coffee-cup"
-  s.version     = "0.0.4"
+  s.version     = "0.0.5"
   s.authors     = ["Sebastien Rosa"]
   s.email       = ["sebastien@demarque.com"]
   s.extra_rdoc_files = ["LICENSE", "README.md"]


### PR DESCRIPTION
RenderView was not working for controllers using namespace.
Add a split on "::" when generating the view method name from "coffee-cup-data" attribute.

J'ai trouvé le problème quand j'ai voulu utiliser du javascript pour une vue d'un controller avec un namespace.